### PR TITLE
fix: route CLI CDN asset links through rustfs-cli release prefix

### DIFF
--- a/components/release.tsx
+++ b/components/release.tsx
@@ -100,7 +100,7 @@ export default function ReleaseCard(props: {
                     <Button asChild size="sm" variant="outline" className="gap-2">
                       <a
                         href={cdnUrl(
-                          `${project.repo}/${release.tag_name}/${asset.name}`
+                          `${project.cdnReleasePrefix || project.repo}/${release.tag_name}/${asset.name}`
                         )}
                       >
                         <Download className="h-4 w-4" />

--- a/projects.config.ts
+++ b/projects.config.ts
@@ -4,6 +4,7 @@ export interface Project {
   repo: string;
   title: string;
   description: string;
+  cdnReleasePrefix?: string;
   links: { label: string, url: string, icon?: LucideIcon }[]
 }
 
@@ -30,6 +31,7 @@ export const projects: Project[] = [
     repo: "cli",
     title: "CLI",
     description: "RustFS CLI, use it to conveniently manage your file system, account permissions, and system status.",
+    cdnReleasePrefix: "rustfs-cli/release",
     links: [
       { label: "Source", url: "https://github.com/rustfs/cli", icon: GithubIcon },
       { label: "Latest Version", url: "https://dl.rustfs.com/artifacts/rustfs-cli/rustfs-cli-latest.zip", icon: PaperclipIcon },


### PR DESCRIPTION
## Summary
- use the RustFS CLI release prefix when building CDN links on release pages
- keep the existing default path logic for other projects
- align CLI download URLs with the OSS layout expected for release assets

## Test Plan
- pnpm lint
- pnpm build